### PR TITLE
Bug fixes

### DIFF
--- a/DigitalComposites/src/service/DCXDropboxSession.m
+++ b/DigitalComposites/src/service/DCXDropboxSession.m
@@ -37,6 +37,7 @@
 #import "DCXUtils.h"
 #import "DCXError.h"
 #import "DCXErrorUtils.h"
+#import "DCXNetworkUtils.h"
 
 NSURL *DropboxApiBaseUrl;
 NSURL *DropboxContentBaseUrl;
@@ -372,6 +373,8 @@ static NSDictionary *DCXTypeSyncGroups = nil;
 {
     NSString *href = [self getHrefForComponent:component ofComposite:composite];
     NSString *urlString = [@"files/sandbox" stringByAppendingPathComponent:href];
+    NSString *componentRev = component.etag;
+    urlString = [NSString stringWithFormat:@"%@?rev=%@", urlString, [DCXNetworkUtils encodeQueryParameterForURLWithString:componentRev]];
     NSURL *url = [self urlFromString:urlString andParams:nil relativeToUrl:DropboxContentBaseUrl];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     
@@ -401,7 +404,7 @@ static NSDictionary *DCXTypeSyncGroups = nil;
                                                                  domain:DCXErrorDomain response:response
                                                                 details:@"Missing metadata field 'rev'"];
                           
-                      } else if (![newEtag isEqualToString:component.etag]) {
+                      } else if (![newEtag isEqualToString:componentRev]) {
                           error = [DCXErrorUtils ErrorWithCode:DCXErrorUnexpectedResponse
                                                                  domain:DCXErrorDomain response:response
                                                                 details:[NSString stringWithFormat:@"Downloaded component has rev %@. Expected: %@",

--- a/DigitalComposites/src/service/DCXHTTPService.m
+++ b/DigitalComposites/src/service/DCXHTTPService.m
@@ -448,7 +448,7 @@ const NSInteger DCXHTTPServiceMaxAuthTokenHistory = 3;
 
             NSInteger statusCode = result.statusCode;
 
-            if (statusCode == 401) // authentication failure
+            if (statusCode == 401 || (statusCode == 400 && _authToken == nil)) // authentication failure
             {
                 result.error = [DCXErrorUtils ErrorWithCode:DCXErrorAuthenticationFailed
                                                               domain:DCXErrorDomain response:result

--- a/DigitalComposites/src/util/DCXNetworkUtils.h
+++ b/DigitalComposites/src/util/DCXNetworkUtils.h
@@ -35,4 +35,6 @@
 + (NSDictionary *)decodeResponseHeaders:(NSDictionary *)source;
 + (NSDictionary *)encodeRequestHeaders:(NSDictionary *)source;
 
++ (NSString *)encodeQueryParameterForURLWithString:(NSString *)string;
+
 @end

--- a/DigitalComposites/src/util/DCXNetworkUtils.m
+++ b/DigitalComposites/src/util/DCXNetworkUtils.m
@@ -174,4 +174,15 @@
     return [NSDictionary dictionaryWithObjects:escapedValues forKeys:keys count:count];
 }
 
++ (NSString *)encodeQueryParameterForURLWithString:(NSString *)string
+{
+    return CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
+                                                                     kCFAllocatorDefault,
+                                                                     (__bridge CFStringRef)(string),
+                                                                     NULL,
+                                                                     (CFStringRef)@":/?#[]@!$&'()*+,;=%\\ ",
+                                                                     kCFStringEncodingUTF8
+                                                                     ));
+}
+
 @end


### PR DESCRIPTION
- Dropbox sometimes returns a 400 instead of a 401 when no token is provided
- The download request for a component must be for the specific revision of the asset on the server
